### PR TITLE
Added build-image.yml workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,18 @@
+name: Build Container Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR merge event or commit message
+        if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'BUILD_CONTAINER_IMAGE')
+        run: |
+          docker build -t your-image .
+          docker push your-image


### PR DESCRIPTION
This workflow automates the process of building and pushing container images to the Docker registry. 

It triggers when pull requests are merged into the main branch or when commit messages contain the 'BUILD_CONTAINER_IMAGE' string.